### PR TITLE
feat: Added Card and Tag removal from Deck

### DIFF
--- a/.savedata_backup.json
+++ b/.savedata_backup.json
@@ -1,41 +1,21 @@
 {
   "deckName": "lky deck",
-  "numCards": 7,
+  "numCards": 3,
   "cards": [
     {
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454",
-      "question": "is akhil a dirty commie",
-      "answer": "yes"
+      "uuid": "98685c9e-91d5-43f6-8d94-e6c73a425f5f",
+      "question": "deck_test_card",
+      "answer": "nothing"
     },
     {
-      "uuid": "00000000-0000-0000-0000-000000000001",
-      "question": "why do other groups keep attackin ian",
-      "answer": "he is not a dirty commie"
+      "uuid": "b4ee4e97-21df-4459-8268-ac7f218cae7d",
+      "question": "tag_test_card",
+      "answer": "nothing"
     },
     {
-      "uuid": "fbfda5e0-7816-493a-a99e-5da006315d17",
-      "question": "how is this",
-      "answer": "dunno"
-    },
-    {
-      "uuid": "5f8a7558-40dc-4e5a-8d3d-44678f3e01f8",
-      "question": "test_deck_creation",
-      "answer": "deck_creation_passed"
-    },
-    {
-      "uuid": "6232a5eb-f3d1-4449-8e0c-8f82187e5fc8",
-      "question": "deck test",
-      "answer": "deck test"
-    },
-    {
-      "uuid": "520f8e00-c6d6-4daa-844f-66566d1f02da",
-      "question": "card_test",
-      "answer": "card_answer"
-    },
-    {
-      "uuid": "39c5c798-092b-4c44-8889-43995b425476",
-      "question": "tag_test",
-      "answer": "tag_answer"
+      "uuid": "463d973a-48d6-45fa-8db1-5aaf4ce19492",
+      "question": "deck_test_tag",
+      "answer": "nothing"
     }
   ]
 }

--- a/.savedata_backup.json
+++ b/.savedata_backup.json
@@ -1,6 +1,6 @@
 {
   "deckName": "lky deck",
-  "numCards": 6,
+  "numCards": 7,
   "cards": [
     {
       "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454",
@@ -28,9 +28,14 @@
       "answer": "deck test"
     },
     {
-      "uuid": "da243c73-4da1-4f24-b3aa-7a5a7d96d2b8",
-      "question": "rename_checker",
-      "answer": "rename_checker"
+      "uuid": "520f8e00-c6d6-4daa-844f-66566d1f02da",
+      "question": "card_test",
+      "answer": "card_answer"
+    },
+    {
+      "uuid": "39c5c798-092b-4c44-8889-43995b425476",
+      "question": "tag_test",
+      "answer": "tag_answer"
     }
   ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,4 +45,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/savedata.json
+++ b/savedata.json
@@ -1,41 +1,21 @@
 {
   "deckName": "lky deck",
-  "numCards": 7,
+  "numCards": 3,
   "cards": [
     {
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454",
-      "question": "is akhil a dirty commie",
-      "answer": "yes"
+      "uuid": "98685c9e-91d5-43f6-8d94-e6c73a425f5f",
+      "question": "deck_test_card",
+      "answer": "nothing"
     },
     {
-      "uuid": "00000000-0000-0000-0000-000000000001",
-      "question": "why do other groups keep attackin ian",
-      "answer": "he is not a dirty commie"
+      "uuid": "b4ee4e97-21df-4459-8268-ac7f218cae7d",
+      "question": "tag_test_card",
+      "answer": "nothing"
     },
     {
-      "uuid": "fbfda5e0-7816-493a-a99e-5da006315d17",
-      "question": "how is this",
-      "answer": "dunno"
-    },
-    {
-      "uuid": "5f8a7558-40dc-4e5a-8d3d-44678f3e01f8",
-      "question": "test_deck_creation",
-      "answer": "deck_creation_passed"
-    },
-    {
-      "uuid": "6232a5eb-f3d1-4449-8e0c-8f82187e5fc8",
-      "question": "deck test",
-      "answer": "deck test"
-    },
-    {
-      "uuid": "520f8e00-c6d6-4daa-844f-66566d1f02da",
-      "question": "card_test",
-      "answer": "card_answer"
-    },
-    {
-      "uuid": "39c5c798-092b-4c44-8889-43995b425476",
-      "question": "tag_test",
-      "answer": "tag_answer"
+      "uuid": "463d973a-48d6-45fa-8db1-5aaf4ce19492",
+      "question": "deck_test_tag",
+      "answer": "nothing"
     }
   ]
 }

--- a/savedata.json
+++ b/savedata.json
@@ -1,6 +1,6 @@
 {
   "deckName": "lky deck",
-  "numCards": 6,
+  "numCards": 7,
   "cards": [
     {
       "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454",
@@ -28,9 +28,14 @@
       "answer": "deck test"
     },
     {
-      "uuid": "da243c73-4da1-4f24-b3aa-7a5a7d96d2b8",
-      "question": "rename_checker",
-      "answer": "rename_checker"
+      "uuid": "520f8e00-c6d6-4daa-844f-66566d1f02da",
+      "question": "card_test",
+      "answer": "card_answer"
+    },
+    {
+      "uuid": "39c5c798-092b-4c44-8889-43995b425476",
+      "question": "tag_test",
+      "answer": "tag_answer"
     }
   ]
 }

--- a/src/main/java/model/Card.java
+++ b/src/main/java/model/Card.java
@@ -79,6 +79,13 @@ public class Card {
     public void removeDecks(DeckUUID deckUUID) {
         decks.remove(deckUUID);
     }
+    public boolean deckEmpty() {
+        return this.decks.isEmpty();
+    }
+
+    public boolean tagEmpty() {
+        return this.tags.isEmpty();
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/model/Deck.java
+++ b/src/main/java/model/Deck.java
@@ -37,6 +37,11 @@ public class Deck {
         return deckName;
     }
 
+
+    public void setTags(ArrayList<TagUUID> tags) {
+        this.tags = tags;
+    }
+
     public DeckUUID getDeckUUID() {
         return deckUUID;
     }
@@ -57,6 +62,10 @@ public class Deck {
     }
     public void addTag(TagUUID tagUUID) {
         this.tags.add(tagUUID);
+    }
+
+    public void setCards(ArrayList<CardUUID> cards) {
+        this.cards = cards;
     }
 
     @Override

--- a/src/main/java/model/Deck.java
+++ b/src/main/java/model/Deck.java
@@ -36,6 +36,23 @@ public class Deck {
     public String getDeckName() {
         return deckName;
     }
+    public boolean cardInDeck(CardUUID cardUUID) {
+        for(CardUUID cardUUIDHolder : cards) {
+            if(cardUUIDHolder.equals(cardUUID)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean tagInDeck(TagUUID tagUUID) {
+        for(TagUUID tagUUIDHolder : tags) {
+            if(tagUUIDHolder.equals(tagUUID)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 
     public void setTags(ArrayList<TagUUID> tags) {

--- a/src/main/java/model/Deck.java
+++ b/src/main/java/model/Deck.java
@@ -36,7 +36,7 @@ public class Deck {
     public String getDeckName() {
         return deckName;
     }
-    public boolean cardInDeck(CardUUID cardUUID) {
+    public boolean cardIsInDeck(CardUUID cardUUID) {
         for(CardUUID cardUUIDHolder : cards) {
             if(cardUUIDHolder.equals(cardUUID)) {
                 return true;
@@ -45,7 +45,7 @@ public class Deck {
         return false;
     }
 
-    public boolean tagInDeck(TagUUID tagUUID) {
+    public boolean tagIsInDeck(TagUUID tagUUID) {
         for(TagUUID tagUUIDHolder : tags) {
             if(tagUUIDHolder.equals(tagUUID)) {
                 return true;

--- a/src/main/java/model/DeckList.java
+++ b/src/main/java/model/DeckList.java
@@ -41,6 +41,15 @@ public class DeckList {
         }
         return null;
     }
+
+    public Deck findDeckFromUUID(DeckUUID deckUUID) {
+        for (Deck deck : deckList) {
+            if (deck.getDeckUUID().equals(deckUUID)) {
+                return deck;
+            }
+        }
+        return null;
+    }
     public void delete(int id) {
         this.deckList.remove(id);
     }

--- a/src/main/java/model/Tag.java
+++ b/src/main/java/model/Tag.java
@@ -26,6 +26,14 @@ public class Tag {
     public void editTagName(String newTagName) {
         this.tagName = newTagName;
     }
+    public boolean cardInTag(CardUUID cardUUID) {
+        for(CardUUID cardUUIDList : cards) {
+            if(cardUUIDList.equals(cardUUID)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public ArrayList<CardUUID> getCardsUUID() {
         return this.cards;

--- a/src/main/java/model/Tag.java
+++ b/src/main/java/model/Tag.java
@@ -15,6 +15,14 @@ public class Tag {
         cards.add(cardUUID);
     }
 
+    public ArrayList<DeckUUID> getDecks() {
+        return decks;
+    }
+
+    public boolean cardEmpty() {
+        return cards.isEmpty();
+    }
+
     public TagUUID getUUID() {
         return this.uuid;
     }
@@ -26,7 +34,7 @@ public class Tag {
     public void editTagName(String newTagName) {
         this.tagName = newTagName;
     }
-    public boolean cardInTag(CardUUID cardUUID) {
+    public boolean cardIsInTag(CardUUID cardUUID) {
         for(CardUUID cardUUIDList : cards) {
             if(cardUUIDList.equals(cardUUID)) {
                 return true;

--- a/src/main/java/utils/UserInterface.java
+++ b/src/main/java/utils/UserInterface.java
@@ -141,6 +141,14 @@ public class UserInterface {
     public void printAddCardToDeckSuccess(CardUUID cardUUID, DeckUUID deckUUID) {
         System.out.println("Successfully added card " + cardUUID + " to deck " + deckUUID);
     }
+
+    public void printRemoveCardFromDeckSuccess(CardUUID cardUUID, String deckName) {
+        System.out.println("Successfully removed card " + cardUUID + " from deck " + deckName);
+    }
+
+    public void printRemoveTagFromDeckSuccess(TagUUID tagUUID, String deckName) {
+        System.out.println("Successfully removed tag " + tagUUID + " from deck " + deckName);
+    }
     public void printAddTagToDeckSuccess(TagUUID tagUUID, DeckUUID deckUUID) {
         System.out.println("Successfully added tag " + tagUUID + " to deck " + deckUUID);
     }

--- a/src/main/java/utils/command/AddCardToDeckCommand.java
+++ b/src/main/java/utils/command/AddCardToDeckCommand.java
@@ -39,7 +39,7 @@ public class AddCardToDeckCommand extends Command {
             ui.printDeckCreationSuccess();
             deckToAdd = new Deck(deckName, cardUUID);
             deckList.addDeck(deckToAdd);
-        } else if(deckToAdd.cardInDeck(cardUUID) == true) {
+        } else if(deckToAdd.cardIsInDeck(cardUUID)) {
             throw new CardInDeckException();
         } else {
             deckToAdd.addCard(cardUUID);

--- a/src/main/java/utils/command/AddCardToDeckCommand.java
+++ b/src/main/java/utils/command/AddCardToDeckCommand.java
@@ -9,6 +9,7 @@ import model.DeckList;
 import model.DeckUUID;
 import model.TagList;
 import utils.UserInterface;
+import utils.exceptions.CardInDeckException;
 import utils.exceptions.InkaException;
 import utils.exceptions.UUIDWrongFormatException;
 import utils.storage.IDataStorage;
@@ -38,6 +39,8 @@ public class AddCardToDeckCommand extends Command {
             ui.printDeckCreationSuccess();
             deckToAdd = new Deck(deckName, cardUUID);
             deckList.addDeck(deckToAdd);
+        } else if(deckToAdd.cardInDeck(cardUUID) == true) {
+            throw new CardInDeckException();
         } else {
             deckToAdd.addCard(cardUUID);
         }

--- a/src/main/java/utils/command/AddCardToTagCommand.java
+++ b/src/main/java/utils/command/AddCardToTagCommand.java
@@ -9,6 +9,7 @@ import model.Tag;
 import model.TagList;
 import model.TagUUID;
 import utils.UserInterface;
+import utils.exceptions.CardInTagException;
 import utils.exceptions.InkaException;
 import utils.exceptions.UUIDWrongFormatException;
 import utils.storage.IDataStorage;
@@ -45,6 +46,8 @@ public class AddCardToTagCommand extends Command {
             ui.printTagCreationSuccess();
             tagToAdd = new Tag(tagName, cardUUID);
             tagList.addTag(tagToAdd);
+        } else if(tagToAdd.cardInTag(cardUUID)) {
+            throw new CardInTagException();
         } else {
             tagToAdd.addCard(cardUUID);
         }

--- a/src/main/java/utils/command/AddCardToTagCommand.java
+++ b/src/main/java/utils/command/AddCardToTagCommand.java
@@ -46,7 +46,7 @@ public class AddCardToTagCommand extends Command {
             ui.printTagCreationSuccess();
             tagToAdd = new Tag(tagName, cardUUID);
             tagList.addTag(tagToAdd);
-        } else if(tagToAdd.cardInTag(cardUUID)) {
+        } else if(tagToAdd.cardIsInTag(cardUUID)) {
             throw new CardInTagException();
         } else {
             tagToAdd.addCard(cardUUID);

--- a/src/main/java/utils/command/AddTagToDeckCommand.java
+++ b/src/main/java/utils/command/AddTagToDeckCommand.java
@@ -10,6 +10,7 @@ import model.TagUUID;
 import utils.UserInterface;
 import utils.exceptions.CreateTagBeforeAddingToDeck;
 import utils.exceptions.InkaException;
+import utils.exceptions.TagInDeckException;
 import utils.exceptions.UUIDWrongFormatException;
 import utils.storage.IDataStorage;
 
@@ -42,6 +43,8 @@ public class AddTagToDeckCommand extends Command {
             ui.printDeckCreationSuccess();
             deckToAdd = new Deck(deckName, tagUUID);
             deckList.addDeck(deckToAdd);
+        } else if(deckToAdd.tagInDeck(tagUUID)) {
+            throw new TagInDeckException();
         } else {
             deckToAdd.addTag(tagUUID);
         }

--- a/src/main/java/utils/command/AddTagToDeckCommand.java
+++ b/src/main/java/utils/command/AddTagToDeckCommand.java
@@ -43,7 +43,7 @@ public class AddTagToDeckCommand extends Command {
             ui.printDeckCreationSuccess();
             deckToAdd = new Deck(deckName, tagUUID);
             deckList.addDeck(deckToAdd);
-        } else if(deckToAdd.tagInDeck(tagUUID)) {
+        } else if(deckToAdd.tagIsInDeck(tagUUID)) {
             throw new TagInDeckException();
         } else {
             deckToAdd.addTag(tagUUID);

--- a/src/main/java/utils/command/DeleteCardCommand.java
+++ b/src/main/java/utils/command/DeleteCardCommand.java
@@ -1,8 +1,13 @@
 package utils.command;
 
+import model.Card;
 import model.CardList;
+import model.Deck;
 import model.DeckList;
+import model.DeckUUID;
+import model.Tag;
 import model.TagList;
+import model.TagUUID;
 import utils.UserInterface;
 import utils.exceptions.UnknownItem;
 import utils.exceptions.InkaException;
@@ -11,20 +16,37 @@ import utils.storage.IDataStorage;
 public class DeleteCardCommand extends Command {
 
     private int index;
+    private Card card;
 
     public DeleteCardCommand(int index) {
         this.index = index;
+    }
+
+    //Assume this is silent removal, no UI message is displayed
+    public void cardRemovalFromDecks (CardList cardList, DeckList deckList)  {
+        this.card = cardList.get(this.index-1);
+        for(DeckUUID deckUUID: card.getDecksUUID()) {
+            Deck deckToDeleteCardFrom = deckList.findDeckFromUUID(deckUUID);
+            deckToDeleteCardFrom.getCardsUUID().remove(card.getUuid());
+        }
+    }
+    public void cardRemovalFromTag(TagList tagList) {
+        for(TagUUID tagUUID: card.getTagsUUID()) {
+            Tag tagToDeleteCardFrom = tagList.findTagFromUUID(tagUUID);
+            tagToDeleteCardFrom.getCardsUUID().remove(card.getUuid());
+        }
     }
 
     @Override
     public void execute(CardList cardList, TagList tagList, DeckList deckList,UserInterface ui, IDataStorage storage)
             throws InkaException {
         try {
-            // if the input is delete 1, this will delete the first element of the array which is element 0.
+            cardRemovalFromDecks(cardList, deckList);
+            cardRemovalFromTag(tagList);
             cardList.delete(this.index - 1);
             ui.printDeleteSuccess();
             ui.printNumOfQuestions(cardList);
-        } catch (IndexOutOfBoundsException e) {
+        } catch (IndexOutOfBoundsException  | NullPointerException e ) {
             throw new UnknownItem();
         }
     }

--- a/src/main/java/utils/command/DeleteDeckCommand.java
+++ b/src/main/java/utils/command/DeleteDeckCommand.java
@@ -55,10 +55,6 @@ public class DeleteDeckCommand extends Command{
             throws InkaException {
         removeDeckFromCards(cardList, deckList, ui);
         removeDeckFromTags(tagList, deckList, ui);
-        boolean isDeleted = deckList.deleteDeckByUUID(deckUUID);
-        if(isDeleted==false) {
-            //throw exception here
-        }
         ui.printRemoveDeckFromDeckList(deckUUID);
     }
 }

--- a/src/main/java/utils/command/DeleteTagCommand.java
+++ b/src/main/java/utils/command/DeleteTagCommand.java
@@ -49,9 +49,9 @@ public class DeleteTagCommand extends Command {
     }
 
     private void removeTagsFromDecks(DeckList deckList) {
-        for(DeckUUID deckUUID: tag.getDecks()) {
+        for(DeckUUID deckUUID: this.tag.getDecks()) {
             Deck deckToDeleteTagFrom = deckList.findDeckFromUUID(deckUUID);
-            deckToDeleteTagFrom.getTagsUUID().remove(tagUUID);
+            deckToDeleteTagFrom.getTagsUUID().remove(tag.getUUID());
         }
     }
 
@@ -60,6 +60,7 @@ public class DeleteTagCommand extends Command {
             throws InkaException {
         removeTagFromCards(cardList, tagList, ui);
         removeTagsFromDecks(deckList);
+        tagList.deleteTagByUUID(this.tagUUID);
         ui.printRemoveTagFromTagList(tagUUID);
     }
 }

--- a/src/main/java/utils/command/ListCardsUnderDeckCommand.java
+++ b/src/main/java/utils/command/ListCardsUnderDeckCommand.java
@@ -20,7 +20,7 @@ public class ListCardsUnderDeckCommand extends Command{
         this.deckName = deckName;
     }
 
-    private CardList findCardSUnderDeck(CardList cardList, DeckList deckList) throws InkaException {
+    private CardList findCardsUnderDeck(CardList cardList, DeckList deckList) throws InkaException {
         Deck foundDeck = deckList.findDeckFromName(deckName);
         if(foundDeck==null) {
             throw new DeckNotFoundException();
@@ -41,7 +41,7 @@ public class ListCardsUnderDeckCommand extends Command{
     @Override
     public void execute(CardList cardList, TagList tagList, DeckList deckList, UserInterface ui, IDataStorage storage)
             throws InkaException {
-        CardList foundCardList = findCardSUnderDeck(cardList, deckList);
+        CardList foundCardList = findCardsUnderDeck(cardList, deckList);
         ui.printCardList(foundCardList);
     }
 }

--- a/src/main/java/utils/command/RemoveCardFromDeckCommand.java
+++ b/src/main/java/utils/command/RemoveCardFromDeckCommand.java
@@ -1,0 +1,52 @@
+package utils.command;
+
+import java.util.ArrayList;
+import java.util.UUID;
+import model.CardList;
+import model.CardUUID;
+import model.Deck;
+import model.DeckList;
+import model.TagList;
+import utils.UserInterface;
+import utils.exceptions.CardNeverWasInDeck;
+import utils.exceptions.DeckNotFoundException;
+import utils.exceptions.InkaException;
+import utils.exceptions.UUIDWrongFormatException;
+import utils.storage.IDataStorage;
+
+public class RemoveCardFromDeckCommand extends Command{
+    private CardUUID cardUUID;
+
+    private String deckName;
+
+    public RemoveCardFromDeckCommand(String cardUUID, String deckName) throws InkaException {
+        this.deckName = deckName;
+        //this.tagName = tagName;
+        try {
+            this.cardUUID = new CardUUID(UUID.fromString(cardUUID));
+        } catch (IllegalArgumentException e) {
+            throw new UUIDWrongFormatException();
+        }
+    }
+
+    public void removeCardFromDeck(DeckList deckList,String deckName, CardUUID cardUUID)
+            throws InkaException {
+        Deck deck = deckList.findDeckFromName(deckName);
+        if(deck==null) {
+            throw new DeckNotFoundException();
+        }
+        ArrayList<CardUUID> deckCardList = deck.getCardsUUID();
+        boolean wasCardInDeck = deckCardList.removeIf(card -> card.equals(cardUUID));
+        if(wasCardInDeck==false) {
+            throw new CardNeverWasInDeck();
+        }
+        deck.setCards(deckCardList);
+    }
+    @Override
+    public void execute(CardList cardList, TagList tagList, DeckList deckList, UserInterface ui, IDataStorage storage)
+            throws InkaException {
+        removeCardFromDeck(deckList, deckName, cardUUID);
+        ui.printRemoveCardFromDeckSuccess(cardUUID, deckName);
+    }
+
+}

--- a/src/main/java/utils/command/RemoveTagFromDeckCommand.java
+++ b/src/main/java/utils/command/RemoveTagFromDeckCommand.java
@@ -1,0 +1,50 @@
+package utils.command;
+
+import java.util.ArrayList;
+import java.util.UUID;
+import model.CardList;
+import model.Deck;
+import model.DeckList;
+import model.TagList;
+import model.TagUUID;
+import utils.UserInterface;
+import utils.exceptions.DeckNotFoundException;
+import utils.exceptions.InkaException;
+import utils.exceptions.TagNeverWasInDeck;
+import utils.exceptions.UUIDWrongFormatException;
+import utils.storage.IDataStorage;
+
+public class RemoveTagFromDeckCommand extends Command {
+    private TagUUID tagUUID;
+    private String deckName;
+
+    public RemoveTagFromDeckCommand(String tagUUID, String deckName) throws InkaException {
+        this.deckName = deckName;
+        //this.tagName = tagName;
+        try {
+            this.tagUUID = new TagUUID(UUID.fromString(tagUUID));
+        } catch (IllegalArgumentException e) {
+            throw new UUIDWrongFormatException();
+        }
+    }
+
+    public void removeTagFromDeck(DeckList deckList,String deckName, TagUUID tagUUID)
+            throws InkaException {
+        Deck deck = deckList.findDeckFromName(deckName);
+        if(deck==null) {
+            throw new DeckNotFoundException();
+        }
+        ArrayList<TagUUID> deckTagList = deck.getTagsUUID();
+        boolean wasTagInDeck = deckTagList.removeIf(tag -> tag.equals(tagUUID));
+        if(wasTagInDeck==false) {
+            throw new TagNeverWasInDeck();
+        }
+        deck.setTags(deckTagList);
+    }
+    @Override
+    public void execute(CardList cardList, TagList tagList, DeckList deckList, UserInterface ui, IDataStorage storage)
+            throws InkaException {
+        removeTagFromDeck(deckList, deckName, tagUUID);
+        ui.printRemoveTagFromDeckSuccess(tagUUID, deckName);
+    }
+}

--- a/src/main/java/utils/exceptions/CardInDeckException.java
+++ b/src/main/java/utils/exceptions/CardInDeckException.java
@@ -1,0 +1,7 @@
+package utils.exceptions;
+
+public class CardInDeckException extends InkaException{
+    public CardInDeckException() {
+        super("Card is already a part of the deck");
+    }
+}

--- a/src/main/java/utils/exceptions/CardInTagException.java
+++ b/src/main/java/utils/exceptions/CardInTagException.java
@@ -1,0 +1,7 @@
+package utils.exceptions;
+
+public class CardInTagException extends InkaException{
+    public CardInTagException() {
+        super("Card is already a part of the Tag");
+    }
+}

--- a/src/main/java/utils/exceptions/CardNeverWasInDeck.java
+++ b/src/main/java/utils/exceptions/CardNeverWasInDeck.java
@@ -1,0 +1,7 @@
+package utils.exceptions;
+
+public class CardNeverWasInDeck extends InkaException {
+    public CardNeverWasInDeck() {
+        super("The card was never in the deck");
+    }
+}

--- a/src/main/java/utils/exceptions/TagInDeckException.java
+++ b/src/main/java/utils/exceptions/TagInDeckException.java
@@ -1,0 +1,7 @@
+package utils.exceptions;
+
+public class TagInDeckException extends InkaException{
+    public TagInDeckException() {
+        super("Tag is already a part of the deck");
+    }
+}

--- a/src/main/java/utils/exceptions/TagNeverWasInDeck.java
+++ b/src/main/java/utils/exceptions/TagNeverWasInDeck.java
@@ -1,0 +1,7 @@
+package utils.exceptions;
+
+public class TagNeverWasInDeck extends InkaException{
+    public TagNeverWasInDeck() {
+        super("Tag was never in deck");
+    }
+}

--- a/src/main/java/utils/parser/DeckKeywordParser.java
+++ b/src/main/java/utils/parser/DeckKeywordParser.java
@@ -30,7 +30,6 @@ public class DeckKeywordParser extends KeywordParser{
     private static Options buildDeleteOptions() {
         Options options = new Options();
         options.addRequiredOption("d", "deck", true, "deck name");
-        // extra stuff down here
         options.addOption("c", "card", true, "card name (optional)");
         options.addOption("t", "tag", true, "tag name (optional)");
 

--- a/src/main/java/utils/parser/DeckKeywordParser.java
+++ b/src/main/java/utils/parser/DeckKeywordParser.java
@@ -31,8 +31,8 @@ public class DeckKeywordParser extends KeywordParser{
         Options options = new Options();
         options.addRequiredOption("d", "deck", true, "deck name");
         // extra stuff down here
-        options.addOption("c", "card", true, "card name");
-        options.addOption("t", "tag", true, "tag name");
+        options.addOption("c", "card", true, "card name (optional)");
+        options.addOption("t", "tag", true, "tag name (optional)");
 
         return options;
     }
@@ -45,8 +45,8 @@ public class DeckKeywordParser extends KeywordParser{
     }
     private static Options buildListOptions() {
         Options options = new Options();
-        options.addOption("c", "cards", true, "deck name");
-        options.addOption("t", "tags", true, "deck name");
+        options.addOption("c", "cards", true, "deck name to list cards from (optional)");
+        options.addOption("t", "tags", true, "deck name to list tags from (optional)");
         return options;
     }
     @Override

--- a/src/main/java/utils/parser/DeckKeywordParser.java
+++ b/src/main/java/utils/parser/DeckKeywordParser.java
@@ -12,6 +12,9 @@ import utils.command.ListCardsUnderDeckCommand;
 import utils.command.ListDecksCommand;
 import utils.command.ListTagsUnderDeckCommand;
 import utils.command.PrintHelpCommand;
+import utils.command.RemoveCardFromDeckCommand;
+import utils.command.RemoveTagFromDeckCommand;
+import utils.exceptions.InkaException;
 import utils.exceptions.UnrecognizedCommandException;
 
 public class DeckKeywordParser extends KeywordParser{
@@ -28,8 +31,8 @@ public class DeckKeywordParser extends KeywordParser{
         Options options = new Options();
         options.addRequiredOption("d", "deck", true, "deck name");
         // extra stuff down here
-        //        options.addOption("c", "card", true, "card name");
-        //        options.addOption("t", "tag", true, "tag name");
+        options.addOption("c", "card", true, "card name");
+        options.addOption("t", "tag", true, "tag name");
 
         return options;
     }
@@ -48,7 +51,7 @@ public class DeckKeywordParser extends KeywordParser{
     }
     @Override
     protected Command handleAction(String action, List<String> tokens)
-            throws ParseException, UnrecognizedCommandException {
+            throws ParseException, UnrecognizedCommandException, InkaException {
         switch (action) {
         case DELETE_ACTION:
             return handleDelete(tokens);
@@ -63,11 +66,17 @@ public class DeckKeywordParser extends KeywordParser{
         }
     }
 
-    private Command handleDelete(List<String> tokens) throws ParseException {
+    private Command handleDelete(List<String> tokens) throws ParseException, InkaException {
         CommandLine cmd = parser.parse(buildDeleteOptions(), tokens.toArray(new String[0]));
 
         String deckName = cmd.getOptionValue("d");
-        return new DeleteDeckCommand(deckName);
+        if(cmd.hasOption("c")) {
+            return new RemoveCardFromDeckCommand(cmd.getOptionValue("c"), deckName);
+        } else if (cmd.hasOption("t")) {
+            return new RemoveTagFromDeckCommand(cmd.getOptionValue("t"), deckName);
+        } else {
+            return new DeleteDeckCommand(deckName);
+        }
     }
 
     private Command handleList(List<String> tokens) throws ParseException {

--- a/src/main/java/utils/parser/TagKeywordParser.java
+++ b/src/main/java/utils/parser/TagKeywordParser.java
@@ -53,7 +53,7 @@ public class TagKeywordParser extends KeywordParser {
 
     private static Options buildListOptions() {
         Options options = new Options();
-        options.addOption("t", "tag", true, "tag name");
+        options.addOption("t", "tag", true, "tag name (optional)");
 
         return options;
     }


### PR DESCRIPTION
Added in Card and Tag Removal for Deck, the current list of Deck features is as such:
- Add card to deck {following tag. not allowing empty decks for the time being}
- Add tag to deck {following tag. not allowing empty decks for the time being}
- Delete Deck
- List cards under deck
- List tags under deck
- list decks
- Edit the deck name
- Remove Card from Deck
- Remove Tag from Deck