### PR TITLE
Fix/tag whitespace

### DIFF
--- a/src/main/java/utils/UserInterface.java
+++ b/src/main/java/utils/UserInterface.java
@@ -145,8 +145,8 @@ public class UserInterface {
         System.out.println("Successfully added tag " + tagUUID + " to deck " + deckUUID);
     }
 
-    public void printTagCreationSuccess() {
-        System.out.println("Tag does not exist.. creating a new one");
+    public void printTagCreationSuccess(String tagName) {
+        System.out.println("Tag does not exist.. creating a new tag: " + tagName);
     }
 
     public void printDeckCreationSuccess() {

--- a/src/main/java/utils/command/AddCardToTagCommand.java
+++ b/src/main/java/utils/command/AddCardToTagCommand.java
@@ -42,7 +42,7 @@ public class AddCardToTagCommand extends Command {
         assert cardToAdd != null;
 
         if (tagToAdd == null) {
-            ui.printTagCreationSuccess();
+            ui.printTagCreationSuccess(tagName);
             tagToAdd = new Tag(tagName, cardUUID);
             tagList.addTag(tagToAdd);
         } else {

--- a/src/main/java/utils/parser/CardKeywordParser.java
+++ b/src/main/java/utils/parser/CardKeywordParser.java
@@ -38,14 +38,10 @@ public class CardKeywordParser extends KeywordParser {
     private static Options buildAddOptions() {
         Options options = new Options();
 
-        Option questionOption = new Option("q", "question", true, "card question");
-        questionOption.setRequired(true);
-        questionOption.setArgs(Option.UNLIMITED_VALUES);
+        Option questionOption = buildMultipleTokenOption("q", "question", true, "card question", true);
         options.addOption(questionOption);
 
-        Option answerOption = new Option("a", "answer", true, "card answer");
-        answerOption.setRequired(true);
-        answerOption.setArgs(Option.UNLIMITED_VALUES);
+        Option answerOption = buildMultipleTokenOption("a", "answer", true, "card answer", true);
         options.addOption(answerOption);
 
         return options;
@@ -65,7 +61,9 @@ public class CardKeywordParser extends KeywordParser {
     private static Options buildTagOptions() {
         Options options = new Options();
         options.addRequiredOption("c", "card", true, "card UUID");
-        options.addRequiredOption("t", "tag", true, "tag name");
+
+        Option tag = buildMultipleTokenOption("t", "tag", true, "tag name", true);
+        options.addOption(tag);
 
         return options;
     }
@@ -132,7 +130,7 @@ public class CardKeywordParser extends KeywordParser {
         // Combine all action
         String[] actionList = {ADD_ACTION, DELETE_ACTION, LIST_ACTION, TAG_ACTION, VIEW_ACTION, DECK_ACTION};
         String[] headerList = new String[]{"Adding cards",
-            "Deleting cards", "List all cards", "Tagging cards", "View cards", "Adding cards to Deck"};
+                "Deleting cards", "List all cards", "Tagging cards", "View cards", "Adding cards to Deck"};
         Options[] optionsList = {buildAddOptions(), buildDeleteOptions(), new Options(), buildTagOptions(),
                 buildViewOptions(), buildDeckOptions()};
         String helpMessage = formatHelpMessage("card", actionList, headerList, optionsList);
@@ -147,9 +145,15 @@ public class CardKeywordParser extends KeywordParser {
         CommandLine cmd = parser.parse(buildTagOptions(), tokens.toArray(new String[0]));
 
         String cardUUID = cmd.getOptionValue("c");
-        String tagName = cmd.getOptionValue("t");
-
-        return new AddCardToTagCommand(tagName, cardUUID);
+        String[] tagNameTokens = cmd.getOptionValues("t");
+        if (tagNameTokens.length > 1) {
+            // Notify user
+            String tagName = String.join("-", tagNameTokens);
+            return new AddCardToTagCommand(tagName, cardUUID);
+        }
+        else {
+            return new AddCardToTagCommand(tagNameTokens[0], cardUUID);
+        }
     }
 
     private Command handleDeck(List<String> tokens) throws ParseException, InkaException {

--- a/src/main/java/utils/parser/CardKeywordParser.java
+++ b/src/main/java/utils/parser/CardKeywordParser.java
@@ -130,7 +130,7 @@ public class CardKeywordParser extends KeywordParser {
         // Combine all action
         String[] actionList = {ADD_ACTION, DELETE_ACTION, LIST_ACTION, TAG_ACTION, VIEW_ACTION, DECK_ACTION};
         String[] headerList = new String[]{"Adding cards",
-                "Deleting cards", "List all cards", "Tagging cards", "View cards", "Adding cards to Deck"};
+            "Deleting cards", "List all cards", "Tagging cards", "View cards", "Adding cards to Deck"};
         Options[] optionsList = {buildAddOptions(), buildDeleteOptions(), new Options(), buildTagOptions(),
                 buildViewOptions(), buildDeckOptions()};
         String helpMessage = formatHelpMessage("card", actionList, headerList, optionsList);

--- a/src/main/java/utils/parser/KeywordParser.java
+++ b/src/main/java/utils/parser/KeywordParser.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.MissingOptionException;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import utils.command.Command;
@@ -22,6 +23,28 @@ public abstract class KeywordParser {
     protected static final int FORMAT_HELP_WIDTH = 200;
     protected static final int FORMAT_HELP_LEFT_PAD = 0;
     protected static final int FORMAT_HELP_DESC_PAD = 10;
+
+    /**
+     * Wrapper around {@link Option} constructor to set option to accept multiple tokens (whitespace-separated
+     * arguments). The arguments to this option should then be obtained using
+     * {@link org.apache.commons.cli.CommandLine#getOptionValues(char)}.
+     *
+     * @param option      See {@link Option#Option(String, String, boolean, String)}
+     * @param longOption  See {@link Option#Option(String, String, boolean, String)}
+     * @param hasArg      See {@link Option#Option(String, String, boolean, String)}
+     * @param description See {@link Option#Option(String, String, boolean, String)}
+     * @param required    If Option is a required option
+     * @return Configured Option
+     */
+    protected static Option buildMultipleTokenOption(String option, String longOption, boolean hasArg,
+            String description,
+            boolean required) {
+        Option opt = new Option(option, longOption, hasArg, description);
+        opt.setArgs(Option.UNLIMITED_VALUES);
+        opt.setRequired(required);
+
+        return opt;
+    }
 
     @SuppressWarnings("unchecked") // Safe, CLI library just returns List instead of List<String>
     public Command parseTokens(List<String> tokens) throws InkaException {

--- a/src/main/java/utils/parser/TagKeywordParser.java
+++ b/src/main/java/utils/parser/TagKeywordParser.java
@@ -3,6 +3,7 @@ package utils.parser;
 import java.util.List;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import utils.command.AddTagToDeckCommand;
@@ -46,14 +47,16 @@ public class TagKeywordParser extends KeywordParser {
     private static Options buildEditOptions() {
         Options options = new Options();
         options.addRequiredOption("o", "old", true, "Old tag name");
-        options.addRequiredOption("n", "new", true, "New tag name");
+
+        Option newTag = buildMultipleTokenOption("n", "new", true, "New tag name", true);
+        options.addOption(newTag);
 
         return options;
     }
 
     private static Options buildListOptions() {
         Options options = new Options();
-        options.addOption("t", "tag", true, "tag name");
+        options.addOption("t", "tag", true, "tag name (optional)");
 
         return options;
     }

--- a/src/test/java/utils/parser/CardParserTest.java
+++ b/src/test/java/utils/parser/CardParserTest.java
@@ -158,14 +158,45 @@ public class CardParserTest {
 
     @Test
     public void parse_card_tag() throws InkaException {
+        cardList.addCard(Card.createCardWithUUID("QUESTION", "ANSWER", "00000000-0000-0000-0000-000000000000"));
         Command cmd = parser.parseCommand("card tag -c 00000000-0000-0000-0000-000000000000 -t tagName");
         assert cmd instanceof AddCardToTagCommand;
+        cmd.execute(cardList, tagList, deckList, ui, storage);
+        assert tagList.findTagFromName("tagName") != null;
     }
 
     @Test
     public void parse_card_tagLongFlag() throws InkaException {
-        Command cmd = parser.parseCommand("card tag --card 00000000-0000-0000-0000-000000000000 --tag tagName");
+        cardList.addCard(Card.createCardWithUUID("QUESTION", "ANSWER", "00000000-0000-0000-0000-000000000000"));
+        Command cmd = parser.parseCommand("card tag -c 00000000-0000-0000-0000-000000000000 --tag tagName");
         assert cmd instanceof AddCardToTagCommand;
+        cmd.execute(cardList, tagList, deckList, ui, storage);
+        assert tagList.findTagFromName("tagName") != null;
+    }
+
+    @Test
+    public void parse_card_tagWhitespaceName() throws InkaException {
+        cardList.addCard(Card.createCardWithUUID("QUESTION", "ANSWER", "00000000-0000-0000-0000-000000000000"));
+        Command cmd = parser.parseCommand("card tag -c 00000000-0000-0000-0000-000000000000 -t tag name");
+        assert cmd instanceof AddCardToTagCommand;
+        cmd.execute(cardList, tagList,deckList, ui, storage);
+        assert tagList.findTagFromName("tag-name") != null;
+    }
+
+    //endregion
+
+    //region `card view` tests
+
+    @Test
+    public void parse_card_view() throws InkaException {
+        Command cmd = parser.parseCommand("card view -c 00000000-0000-0000-0000-000000000000 ");
+        assert cmd instanceof ViewCardCommand;
+    }
+
+    @Test
+    public void parse_card_viewLongFlag() throws InkaException {
+        Command cmd = parser.parseCommand("card view --card 00000000-0000-0000-0000-000000000000");
+        assert cmd instanceof ViewCardCommand;
     }
 
     @Test
@@ -184,22 +215,6 @@ public class CardParserTest {
             assertThrows(InvalidSyntaxException.class, () -> parser.parseCommand(testInput),
                     "Should be invalid syntax");
         }
-    }
-
-    //endregion
-
-    //region `card view` tests
-
-    @Test
-    public void parse_card_view() throws InkaException {
-        Command cmd = parser.parseCommand("card view -c 00000000-0000-0000-0000-000000000000 ");
-        assert cmd instanceof ViewCardCommand;
-    }
-
-    @Test
-    public void parse_card_viewLongFlag() throws InkaException {
-        Command cmd = parser.parseCommand("card view --card 00000000-0000-0000-0000-000000000000");
-        assert cmd instanceof ViewCardCommand;
     }
 
     //endregion

--- a/src/test/java/utils/parser/TagParserTest.java
+++ b/src/test/java/utils/parser/TagParserTest.java
@@ -2,8 +2,10 @@ package utils.parser;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.UUID;
 import model.Card;
 import model.CardList;
+import model.CardUUID;
 import model.DeckList;
 import model.Tag;
 import model.TagList;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import utils.UserInterface;
 import utils.command.Command;
 import utils.command.DeleteTagCommand;
+import utils.command.EditTagNameCommand;
 import utils.command.ListCardsUnderTagCommand;
 import utils.command.ListTagsCommand;
 import utils.exceptions.InkaException;
@@ -66,7 +69,7 @@ public class TagParserTest {
 
         Command cmd = parser.parseCommand("tag delete -t tagName");
         assert cmd instanceof DeleteTagCommand;
-        cmd.execute(cardList, tagList, deckList,ui, storage);
+        cmd.execute(cardList, tagList, deckList, ui, storage);
         assert tagList.isEmpty();
     }
 
@@ -74,7 +77,27 @@ public class TagParserTest {
     public void parse_tag_deleteUnknownTag() throws InkaException {
         Command cmd = parser.parseCommand("tag delete -t tagName");
         assert cmd instanceof DeleteTagCommand;
-        assertThrows(TagNotFoundException.class, () -> cmd.execute(cardList, tagList, deckList,ui, storage),
+        assertThrows(TagNotFoundException.class, () -> cmd.execute(cardList, tagList, deckList, ui, storage),
+                "Should not delete non-existent tag");
+    }
+
+    @Test
+    public void parse_tag_edit() throws InkaException {
+        CardUUID cardUUID = new CardUUID(UUID.fromString("00000000-0000-0000-0000-000000000000"));
+        tagList.addTag(new Tag("oldTag", cardUUID));
+
+        Command cmd = parser.parseCommand("tag edit -o oldTag -n newTag");
+        assert cmd instanceof EditTagNameCommand;
+        cmd.execute(cardList, tagList, deckList, ui, storage);
+        assert tagList.findTagFromName("oldTag") == null;
+        assert tagList.findTagFromName("newTag") != null;
+    }
+
+    @Test
+    public void parse_tag_editUnknownTag() throws InkaException {
+        Command cmd = parser.parseCommand("tag edit -o oldTag -n newTag");
+        assert cmd instanceof EditTagNameCommand;
+        assertThrows(TagNotFoundException.class, () -> cmd.execute(cardList, tagList, deckList, ui, storage),
                 "Should not delete non-existent tag");
     }
 }


### PR DESCRIPTION
Fixes #56 
- Pulled out multiple-token option into KeywordParser since this is shared by questions/answers/tags
- Prints the created tag name to make it more explict to user that we are converting to kebab case