### PR TITLE
feat: unified interface for card

### DIFF
--- a/src/main/java/model/CardList.java
+++ b/src/main/java/model/CardList.java
@@ -2,6 +2,7 @@ package model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import utils.exceptions.CardNotFoundException;
 
 public class CardList {
@@ -22,8 +23,32 @@ public class CardList {
         this.cards.add(card);
     }
 
-    public void delete(int id) {
+    public void delete(int id) throws IndexOutOfBoundsException {
         this.cards.remove(id);
+    }
+
+    public void delete(CardSelector cardSelector) throws CardNotFoundException {
+        Optional<Integer> index = cardSelector.getIndex();
+        Optional<CardUUID> uuid = cardSelector.getUuid();
+
+        if (index.isPresent()) {
+            // Index from user input is 1-indexed
+            try {
+                delete(index.get() - 1);
+                return;
+            } catch (IndexOutOfBoundsException e) {
+                throw new CardNotFoundException();
+            }
+        } else if (uuid.isPresent()) {
+            for (int i = 0; i < cards.size(); i++) {
+                if (cards.get(i).getUuid().equals(uuid.get())) {
+                    delete(i);
+                    return;
+                }
+            }
+        }
+
+        throw new CardNotFoundException();
     }
 
     public List<Card> getCards() {
@@ -33,9 +58,9 @@ public class CardList {
     /**
      * Find the card with cardUUID from the cardList.
      *
-     * @param cardUUID
+     * @param cardUUID Card with UUID to find
      * @return The card with the cardUUID specified that exists in the cardList
-     * @throws CardNotFoundException
+     * @throws CardNotFoundException No card with
      */
     public Card findCardFromUUID(CardUUID cardUUID) throws CardNotFoundException {
         for (Card card : cards) {
@@ -44,6 +69,17 @@ public class CardList {
             }
         }
         throw new CardNotFoundException();
+    }
+
+    public Card findCard(CardSelector cardSelector) throws CardNotFoundException {
+        if (cardSelector.getIndex().isPresent()) {
+            // Index from user input is 1-indexed
+            return cards.get(cardSelector.getIndex().get() - 1);
+        } else if (cardSelector.getUuid().isPresent()){
+            return findCardFromUUID(cardSelector.getUuid().get());
+        }
+
+        return null;
     }
 
     public boolean isEmpty() {

--- a/src/main/java/model/CardList.java
+++ b/src/main/java/model/CardList.java
@@ -74,8 +74,12 @@ public class CardList {
     public Card findCard(CardSelector cardSelector) throws CardNotFoundException {
         if (cardSelector.getIndex().isPresent()) {
             // Index from user input is 1-indexed
-            return cards.get(cardSelector.getIndex().get() - 1);
-        } else if (cardSelector.getUuid().isPresent()){
+            try {
+                return cards.get(cardSelector.getIndex().get() - 1);
+            } catch (IndexOutOfBoundsException e) {
+                throw new CardNotFoundException();
+            }
+        } else if (cardSelector.getUuid().isPresent()) {
             return findCardFromUUID(cardSelector.getUuid().get());
         }
 

--- a/src/main/java/model/CardSelector.java
+++ b/src/main/java/model/CardSelector.java
@@ -1,0 +1,25 @@
+package model;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class CardSelector {
+    private Optional<CardUUID> uuid = Optional.empty();
+    private Optional<Integer> index = Optional.empty();
+
+    public CardSelector(String uuid) {
+        this.uuid = Optional.of(new CardUUID(UUID.fromString(uuid)));
+    }
+
+    public CardSelector(int index) {
+        this.index = Optional.of(index);
+    }
+
+    public Optional<CardUUID> getUuid() {
+        return uuid;
+    }
+
+    public Optional<Integer> getIndex() {
+        return index;
+    }
+}

--- a/src/main/java/utils/command/AddCardToDeckCommand.java
+++ b/src/main/java/utils/command/AddCardToDeckCommand.java
@@ -23,7 +23,7 @@ public class AddCardToDeckCommand extends Command {
         this.cardSelector = cardSelector;
     }
 
-    private void addCardToDeck(DeckList deckList, Card cardToAdd, UserInterface ui) {
+    private void addCardToDeck(DeckList deckList, Card cardToAdd, UserInterface ui) throws CardInDeckException {
         //find the corresponding Deck and Card based on its deckName and card uuid
         Deck deckToAdd = deckList.findDeckFromName(deckName);
 
@@ -31,7 +31,7 @@ public class AddCardToDeckCommand extends Command {
             ui.printDeckCreationSuccess();
             deckToAdd = new Deck(deckName, cardToAdd.getUuid());
             deckList.addDeck(deckToAdd);
-        } else if(deckToAdd.cardIsInDeck(cardUUID)) {
+        } else if (deckToAdd.cardIsInDeck(cardToAdd.getUuid())) {
             throw new CardInDeckException();
         } else {
             deckToAdd.addCard(cardToAdd.getUuid());

--- a/src/main/java/utils/command/AddCardToTagCommand.java
+++ b/src/main/java/utils/command/AddCardToTagCommand.java
@@ -33,9 +33,8 @@ public class AddCardToTagCommand extends Command {
      * @param tagList   The tagList into which to add the tag that has been created
      * @param cardToAdd The card to add to tag
      * @param ui        The userInterface to print the success of the tag creation
-     * @throws InkaException
      */
-    private void addCardToTag(TagList tagList, Card cardToAdd, UserInterface ui) {
+    private void addCardToTag(TagList tagList, Card cardToAdd, UserInterface ui) throws CardInTagException {
         //find the corresponding Tag and Card based on its tagName and card uuid
         Tag tagToAdd = tagList.findTagFromName(tagName);
 
@@ -43,7 +42,7 @@ public class AddCardToTagCommand extends Command {
             ui.printTagCreationSuccess(tagName);
             tagToAdd = new Tag(tagName, cardToAdd.getUuid());
             tagList.addTag(tagToAdd);
-        } else if(tagToAdd.cardIsInTag(cardUUID)) {
+        } else if (tagToAdd.cardIsInTag(cardToAdd.getUuid())) {
             throw new CardInTagException();
         } else {
             tagToAdd.addCard(cardToAdd.getUuid());

--- a/src/main/java/utils/command/ViewCardCommand.java
+++ b/src/main/java/utils/command/ViewCardCommand.java
@@ -1,11 +1,9 @@
 package utils.command;
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import model.Card;
 import model.CardList;
-import model.CardUUID;
+import model.CardSelector;
 import model.DeckList;
 import model.Tag;
 import model.TagList;
@@ -13,18 +11,13 @@ import model.TagUUID;
 import utils.UserInterface;
 import utils.exceptions.CardNotFoundException;
 import utils.exceptions.InkaException;
-import utils.exceptions.UUIDWrongFormatException;
 import utils.storage.IDataStorage;
 
 public class ViewCardCommand extends Command {
-    private CardUUID cardUUID;
+    private CardSelector cardSelector;
 
-    public ViewCardCommand(String cardUUID) throws InkaException {
-        try {
-            this.cardUUID = new CardUUID(UUID.fromString(cardUUID));
-        } catch (IllegalArgumentException e) {
-            throw new UUIDWrongFormatException();
-        }
+    public ViewCardCommand(CardSelector cardSelector) {
+        this.cardSelector = cardSelector;
     }
 
     /**
@@ -46,23 +39,18 @@ public class ViewCardCommand extends Command {
         return tags;
     }
 
-    public void execute(CardList cardList, TagList tagList, DeckList deckList,UserInterface ui, IDataStorage storage)
+    public void execute(CardList cardList, TagList tagList, DeckList deckList, UserInterface ui, IDataStorage storage)
             throws InkaException {
-        List<Card> cards = cardList.getCards();
+        Card card = cardList.findCard(cardSelector);
         ArrayList<Tag> tags;
-        boolean cardFound = false;
 
         //find the card with the specified uuid, print the card, find all the tags under it, print all the tags
-        for (Card card : cards) {
-            if (card.getUuid().equals(cardUUID)) {
-                cardFound = true;
-                ui.printCard(card);
-                ArrayList<TagUUID> tagsUUID = card.getTagsUUID();
-                tags = findTagsFromTagUUID(tagsUUID, tagList);
-                ui.printTags(tags);
-            }
-        }
-        if (!cardFound) {
+        if (card != null) {
+            ui.printCard(card);
+            ArrayList<TagUUID> tagsUUID = card.getTagsUUID();
+            tags = findTagsFromTagUUID(tagsUUID, tagList);
+            ui.printTags(tags);
+        } else {
             throw new CardNotFoundException();
         }
     }

--- a/src/main/java/utils/parser/CardKeywordParser.java
+++ b/src/main/java/utils/parser/CardKeywordParser.java
@@ -2,6 +2,7 @@ package utils.parser;
 
 import java.util.List;
 import model.Card;
+import model.CardSelector;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
@@ -49,18 +50,14 @@ public class CardKeywordParser extends KeywordParser {
 
     private static Options buildDeleteOptions() {
         Options options = new Options();
-
-        Option indexOption = new Option("i", "index", true, "card index");
-        indexOption.setRequired(true);
-        indexOption.setType(Number.class);
-        options.addOption(indexOption);
+        options.addOptionGroup(buildCardSelectOption());
 
         return options;
     }
 
     private static Options buildTagOptions() {
         Options options = new Options();
-        options.addRequiredOption("c", "card", true, "card UUID");
+        options.addOptionGroup(buildCardSelectOption());
 
         Option tag = buildMultipleTokenOption("t", "tag", true, "tag name", true);
         options.addOption(tag);
@@ -70,7 +67,7 @@ public class CardKeywordParser extends KeywordParser {
 
     private static Options buildDeckOptions() {
         Options options = new Options();
-        options.addRequiredOption("c", "card", true, "card UUID");
+        options.addOptionGroup(buildCardSelectOption());
         options.addRequiredOption("d", "deck", true, "deck name");
 
         return options;
@@ -78,7 +75,7 @@ public class CardKeywordParser extends KeywordParser {
 
     private static Options buildViewOptions() {
         Options options = new Options();
-        options.addRequiredOption("c", "card", true, "card UUID");
+        options.addOptionGroup(buildCardSelectOption());
 
         return options;
     }
@@ -119,10 +116,9 @@ public class CardKeywordParser extends KeywordParser {
 
     private Command handleDelete(List<String> tokens) throws ParseException {
         CommandLine cmd = parser.parse(buildDeleteOptions(), tokens.toArray(new String[0]));
+        CardSelector cardSelector = getSelectedCard(cmd);
 
-        int deleteIndex = ((Number) cmd.getParsedOptionValue("i")).intValue();
-
-        return new DeleteCardCommand(deleteIndex);
+        return new DeleteCardCommand(cardSelector);
     }
 
     //TODO: Fix issue here
@@ -143,32 +139,32 @@ public class CardKeywordParser extends KeywordParser {
 
     private Command handleTag(List<String> tokens) throws ParseException, InkaException {
         CommandLine cmd = parser.parse(buildTagOptions(), tokens.toArray(new String[0]));
+        CardSelector cardSelector = getSelectedCard(cmd);
 
-        String cardUUID = cmd.getOptionValue("c");
         String[] tagNameTokens = cmd.getOptionValues("t");
         if (tagNameTokens.length > 1) {
             // Notify user
             String tagName = String.join("-", tagNameTokens);
-            return new AddCardToTagCommand(tagName, cardUUID);
+            return new AddCardToTagCommand(tagName, cardSelector);
         }
         else {
-            return new AddCardToTagCommand(tagNameTokens[0], cardUUID);
+            return new AddCardToTagCommand(tagNameTokens[0], cardSelector);
         }
     }
 
     private Command handleDeck(List<String> tokens) throws ParseException, InkaException {
         CommandLine cmd = parser.parse(buildDeckOptions(), tokens.toArray(new String[0]));
 
-        String cardUUID = cmd.getOptionValue("c");
+        CardSelector cardSelector = getSelectedCard(cmd);
         String deckName = cmd.getOptionValue("d");
 
-        return new AddCardToDeckCommand(deckName, cardUUID);
+        return new AddCardToDeckCommand(deckName, cardSelector);
     }
 
     private Command handleView(List<String> tokens) throws ParseException, InkaException {
         CommandLine cmd = parser.parse(buildViewOptions(), tokens.toArray(new String[0]));
+        CardSelector cardSelector = getSelectedCard(cmd);
 
-        String cardUUID = cmd.getOptionValue("c");
-        return new ViewCardCommand(cardUUID);
+        return new ViewCardCommand(cardSelector);
     }
 }

--- a/src/main/java/utils/parser/KeywordParser.java
+++ b/src/main/java/utils/parser/KeywordParser.java
@@ -110,10 +110,10 @@ public abstract class KeywordParser {
             for (Object obj : e.getMissingOptions()) {
                 if (obj instanceof String) {
                     missingOptions.add((String) obj);
-                }
-                else if (obj instanceof OptionGroup) {
+                } else if (obj instanceof OptionGroup) {
                     OptionGroup optionGroup = (OptionGroup) obj;
-                    String optionsInGroup = optionGroup.getOptions().stream().map(option -> "-" + option.getOpt()).collect(Collectors.joining("/"));
+                    String optionsInGroup = optionGroup.getOptions().stream().map(option -> "-" + option.getOpt())
+                            .collect(Collectors.joining("/"));
                     missingOptions.add(optionsInGroup);
                 }
             }

--- a/src/main/java/utils/parser/Parser.java
+++ b/src/main/java/utils/parser/Parser.java
@@ -21,7 +21,6 @@ public class Parser {
     // Keyword-specific parsers
     private final CardKeywordParser cardKeywordParser = new CardKeywordParser();
     private final TagKeywordParser tagKeywordParser = new TagKeywordParser();
-
     private final DeckKeywordParser deckKeywordParser = new DeckKeywordParser();
 
     private boolean isExecuting;

--- a/src/test/java/utils/parser/CardParserTest.java
+++ b/src/test/java/utils/parser/CardParserTest.java
@@ -14,7 +14,7 @@ import utils.command.AddCardToTagCommand;
 import utils.command.Command;
 import utils.command.DeleteCardCommand;
 import utils.command.ViewCardCommand;
-import utils.exceptions.UnknownItem;
+import utils.exceptions.CardNotFoundException;
 import utils.exceptions.InkaException;
 import utils.exceptions.InvalidSyntaxException;
 import utils.storage.FakeStorage;
@@ -46,7 +46,7 @@ public class CardParserTest {
     public void parse_card_add() throws InkaException {
         Command cmd = parser.parseCommand("card add -q QUESTION -a ANSWER");
         assert cmd instanceof AddCardCommand;
-        cmd.execute(cardList, tagList, deckList , ui, storage);
+        cmd.execute(cardList, tagList, deckList, ui, storage);
 
         Card card = cardList.get(0);
         assert card.getQuestion().equals("QUESTION") : "Unexpected question parsed";
@@ -57,7 +57,7 @@ public class CardParserTest {
     public void parse_card_addLongFlag() throws InkaException {
         Command cmd = parser.parseCommand("card add --question QUESTION --answer ANSWER");
         assert cmd instanceof AddCardCommand;
-        cmd.execute(cardList, tagList, deckList ,ui, storage);
+        cmd.execute(cardList, tagList, deckList, ui, storage);
 
         Card card = cardList.get(0);
         assert card.getQuestion().equals("QUESTION") : "Unexpected question parsed";
@@ -68,7 +68,7 @@ public class CardParserTest {
     public void parse_card_addWithWhitespaces() throws InkaException {
         Command cmd = parser.parseCommand("card add -q MULTI WORD QUESTION -a MULTI WORD ANSWER");
         assert cmd instanceof AddCardCommand;
-        cmd.execute(cardList, tagList, deckList ,ui, storage);
+        cmd.execute(cardList, tagList, deckList, ui, storage);
 
         Card card = cardList.get(0);
         assert card.getQuestion().equals("MULTI WORD QUESTION") : "Unexpected question parsed";
@@ -98,30 +98,36 @@ public class CardParserTest {
 
     @Test
     public void parse_card_delete() throws InkaException {
-        cardList.addCard(new Card("QUESTION", "ANSWER"));
+        String[] testInputs = {"card delete -i 1", "card delete -c 00000000-0000-0000-0000-000000000000"};
+        for (String testInput : testInputs) {
+            cardList.addCard(Card.createCardWithUUID("QUESTION", "ANSWER", "00000000-0000-0000-0000-000000000000"));
 
-        Command cmd = parser.parseCommand("card delete -i 1");
-        assert cmd instanceof DeleteCardCommand;
-        cmd.execute(cardList, tagList, deckList, ui, storage);
+            Command cmd = parser.parseCommand(testInput);
+            assert cmd instanceof DeleteCardCommand;
+            cmd.execute(cardList, tagList, deckList, ui, storage);
 
-        assert cardList.isEmpty() : "Should have deleted Card";
+            assert cardList.isEmpty() : "Should have deleted Card";
+        }
     }
 
     @Test
     public void parse_card_deleteLongFlag() throws InkaException {
-        cardList.addCard(new Card("QUESTION", "ANSWER"));
+        String[] testInputs = {"card delete --index 1", "card delete --card 00000000-0000-0000-0000-000000000000"};
+        for (String testInput : testInputs) {
+            cardList.addCard(Card.createCardWithUUID("QUESTION", "ANSWER", "00000000-0000-0000-0000-000000000000"));
 
-        Command cmd = parser.parseCommand("card delete --index 1");
-        assert cmd instanceof DeleteCardCommand;
-        cmd.execute(cardList, tagList, deckList,ui, storage);
+            Command cmd = parser.parseCommand(testInput);
+            assert cmd instanceof DeleteCardCommand;
+            cmd.execute(cardList, tagList, deckList, ui, storage);
 
-        assert cardList.isEmpty() : "Should have deleted Card";
+            assert cardList.isEmpty() : "Should have deleted Card";
+        }
     }
 
     @Test
     public void parse_card_deleteEmpty() throws InkaException {
         Command cmd = parser.parseCommand("card delete -i 1");
-        assertThrows(UnknownItem.class, () -> cmd.execute(cardList, tagList, deckList,ui, storage),
+        assertThrows(CardNotFoundException.class, () -> cmd.execute(cardList, tagList, deckList, ui, storage),
                 "Should fail to delete nothing");
     }
 
@@ -130,7 +136,7 @@ public class CardParserTest {
         cardList.addCard(new Card("QUESTION", "ANSWER"));
 
         Command cmd = parser.parseCommand("card delete -i 0");
-        assertThrows(UnknownItem.class, () -> cmd.execute(cardList, tagList, deckList,ui, storage),
+        assertThrows(CardNotFoundException.class, () -> cmd.execute(cardList, tagList, deckList, ui, storage),
                 "Should fail to delete nothing");
     }
 
@@ -179,7 +185,7 @@ public class CardParserTest {
         cardList.addCard(Card.createCardWithUUID("QUESTION", "ANSWER", "00000000-0000-0000-0000-000000000000"));
         Command cmd = parser.parseCommand("card tag -c 00000000-0000-0000-0000-000000000000 -t tag name");
         assert cmd instanceof AddCardToTagCommand;
-        cmd.execute(cardList, tagList,deckList, ui, storage);
+        cmd.execute(cardList, tagList, deckList, ui, storage);
         assert tagList.findTagFromName("tag-name") != null;
     }
 
@@ -189,14 +195,26 @@ public class CardParserTest {
 
     @Test
     public void parse_card_view() throws InkaException {
-        Command cmd = parser.parseCommand("card view -c 00000000-0000-0000-0000-000000000000 ");
-        assert cmd instanceof ViewCardCommand;
+        String[] testInputs = {"card view -i 1", "card view -c 00000000-0000-0000-0000-000000000000"};
+        for (String testInput : testInputs) {
+            cardList.addCard(Card.createCardWithUUID("QUESTION", "ANSWER", "00000000-0000-0000-0000-000000000000"));
+
+            Command cmd = parser.parseCommand(testInput);
+            assert cmd instanceof ViewCardCommand;
+            cmd.execute(cardList, tagList, deckList, ui, storage);
+        }
     }
 
     @Test
     public void parse_card_viewLongFlag() throws InkaException {
-        Command cmd = parser.parseCommand("card view --card 00000000-0000-0000-0000-000000000000");
-        assert cmd instanceof ViewCardCommand;
+        String[] testInputs = {"card view --index 1", "card view --card 00000000-0000-0000-0000-000000000000"};
+        for (String testInput : testInputs) {
+            cardList.addCard(Card.createCardWithUUID("QUESTION", "ANSWER", "00000000-0000-0000-0000-000000000000"));
+
+            Command cmd = parser.parseCommand(testInput);
+            assert cmd instanceof ViewCardCommand;
+            cmd.execute(cardList, tagList, deckList, ui, storage);
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #72:
- Add mutually exclusive `OptionGroup` to specify card by index OR UUID
- Adds `CardSelector` to pass either card index or card UUID when selecting a `Card`
- `Command::execute` then uses `CardSelector` with `CardList` to find the corresponding card and apply the appropriate action