### PR TITLE
InkaUUID superclass

### DIFF
--- a/src/main/java/model/CardList.java
+++ b/src/main/java/model/CardList.java
@@ -41,7 +41,7 @@ public class CardList {
             }
         } else if (uuid.isPresent()) {
             for (int i = 0; i < cards.size(); i++) {
-                if (cards.get(i).getUuid().equals(uuid.get())) {
+                if (cards.get(i).getUuid().equals(uuid.get().uuid)) {
                     delete(i);
                     return;
                 }
@@ -64,7 +64,7 @@ public class CardList {
      */
     public Card findCardFromUUID(CardUUID cardUUID) throws CardNotFoundException {
         for (Card card : cards) {
-            if (card.getUuid().equals(cardUUID)) {
+            if (card.getUuid().equals(cardUUID.uuid)) {
                 return card;
             }
         }

--- a/src/main/java/model/CardUUID.java
+++ b/src/main/java/model/CardUUID.java
@@ -3,19 +3,8 @@ package model;
 import java.util.UUID;
 
 public class CardUUID extends InkaUUID {
-//    UUID uuid;
 
     public CardUUID(UUID uuid) {
-//        this.uuid = uuid;
         super(uuid);
     }
-
-//    public boolean equals(CardUUID cardUUID) {
-//        return this.uuid.equals(cardUUID.uuid);
-//    }
-//
-//    @Override
-//    public String toString() {
-//        return this.uuid.toString();
-//    }
 }

--- a/src/main/java/model/CardUUID.java
+++ b/src/main/java/model/CardUUID.java
@@ -2,19 +2,20 @@ package model;
 
 import java.util.UUID;
 
-public class CardUUID {
-    UUID uuid;
+public class CardUUID extends InkaUUID {
+//    UUID uuid;
 
     public CardUUID(UUID uuid) {
-        this.uuid = uuid;
+//        this.uuid = uuid;
+        super(uuid);
     }
 
-    public boolean equals(CardUUID cardUUID) {
-        return this.uuid.equals(cardUUID.uuid);
-    }
-
-    @Override
-    public String toString() {
-        return this.uuid.toString();
-    }
+//    public boolean equals(CardUUID cardUUID) {
+//        return this.uuid.equals(cardUUID.uuid);
+//    }
+//
+//    @Override
+//    public String toString() {
+//        return this.uuid.toString();
+//    }
 }

--- a/src/main/java/model/DeckList.java
+++ b/src/main/java/model/DeckList.java
@@ -22,8 +22,8 @@ public class DeckList {
         this.deckList.add(deck);
     }
 
-    public boolean deleteDeckByUUID(DeckUUID uuid) {
-        return deckList.removeIf(deck -> (deck.getDeckUUID().equals(uuid)));
+    public boolean deleteDeckByUUID(DeckUUID deckUUID) {
+        return deckList.removeIf(deck -> (deck.getDeckUUID().equals(deckUUID.uuid)));
     }
 
     public boolean isEmpty() {
@@ -49,7 +49,7 @@ public class DeckList {
 
     public Deck findDeckFromUUID(DeckUUID deckUUID) {
         for (Deck deck : deckList) {
-            if (deck.getDeckUUID().equals(deckUUID)) {
+            if (deck.getDeckUUID().equals(deckUUID.uuid)) {
                 return deck;
             }
         }

--- a/src/main/java/model/DeckUUID.java
+++ b/src/main/java/model/DeckUUID.java
@@ -1,19 +1,9 @@
 package model;
 
 import java.util.UUID;
-public class DeckUUID {
-    UUID uuid;
 
+public class DeckUUID extends InkaUUID {
     public DeckUUID(UUID uuid) {
-        this.uuid = uuid;
-    }
-
-    public boolean equals(DeckUUID deckUUID) {
-        return this.uuid.equals(deckUUID.uuid);
-    }
-
-    @Override
-    public String toString() {
-        return this.uuid.toString();
+        super(uuid);
     }
 }

--- a/src/main/java/model/InkaUUID.java
+++ b/src/main/java/model/InkaUUID.java
@@ -1,0 +1,21 @@
+package model;
+
+import java.util.UUID;
+
+public class InkaUUID {
+
+    UUID uuid;
+
+    public InkaUUID(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public boolean equals(UUID uuid) {
+        return this.uuid.equals(uuid);
+    }
+
+    @Override
+    public String toString() {
+        return this.uuid.toString();
+    }
+}

--- a/src/main/java/model/TagList.java
+++ b/src/main/java/model/TagList.java
@@ -43,15 +43,15 @@ public class TagList {
 
     public Tag findTagFromUUID(TagUUID tagUUID) {
         for (Tag tag : tags) {
-            if (tag.getUUID().equals(tagUUID)) {
+            if (tag.getUUID().equals(tagUUID.uuid)) {
                 return tag;
             }
         }
         return null;
     }
 
-    public boolean deleteTagByUUID(TagUUID uuid) {
-        return tags.removeIf(tag -> (tag.getUUID().equals(uuid)));
+    public boolean deleteTagByUUID(TagUUID tagUUID) {
+        return tags.removeIf(tag -> (tag.getUUID().equals(tagUUID.uuid)));
     }
 
     public void delete(int id) {

--- a/src/main/java/model/TagUUID.java
+++ b/src/main/java/model/TagUUID.java
@@ -2,19 +2,8 @@ package model;
 
 import java.util.UUID;
 
-public class TagUUID {
-    UUID uuid;
-
+public class TagUUID extends InkaUUID {
     public TagUUID(UUID uuid) {
-        this.uuid = uuid;
-    }
-
-    public boolean equals(TagUUID tagUUID) {
-        return this.uuid.equals(tagUUID.uuid);
-    }
-
-    @Override
-    public String toString() {
-        return this.uuid.toString();
+        super(uuid);
     }
 }


### PR DESCRIPTION
- Add `InkaUUID` superclass so that `cardUUID`, `tagUUID `,and `deckUUID` do not need to repeat the exact same methods
- `cardUUID`, `tagUUID` and `deckUUID` now inherits from `InkaUUID`
- now we need to call `cardUUID.equals(cardUUID.uuid) `instead of `cardUUID.equals(cardUUID)` , `tagUUID.equals(tagUUID.uuid) `instead of `tagUUID.equals(tagUUID)` , `deckUUID.equals(deckUUID.uuid) `instead of `deckUUID.equals(deckUUID)` . This has been refactored accordingly but if you need to use the `.equals()` function of either 3 classes please take note of this.